### PR TITLE
fix: protect enqueue_assets() from null

### DIFF
--- a/include/ThePaste/Admin/Admin.php
+++ b/include/ThePaste/Admin/Admin.php
@@ -126,8 +126,12 @@ class Admin extends Core\Singleton {
 	 *	@action admin_print_scripts
 	 */
 	public function enqueue_assets() {
-		$this->css->enqueue();
-		$this->js->enqueue();
+        if ($this && $this->css) {
+            $this->css->enqueue();
+        }
+        if ($this && $this->js) {
+            $this->js->enqueue();
+        }
 	}
 
 	/**


### PR DESCRIPTION
An interaction with the All In One SEO Framework causes The Paste to have enqueue_assets() called w/ css unset.