### PR TITLE
Fix current_user_can parameters

### DIFF
--- a/include/ThePaste/Admin/User.php
+++ b/include/ThePaste/Admin/User.php
@@ -56,7 +56,7 @@ class User extends Core\Singleton {
 	 */
 	public function personal_options( $profile_user ) {
 
-		$can_edit = user_can( $profile_user, 'edit_posts' ) || current_user_can( $profile_user, 'edit_pages' );
+		$can_edit = user_can( $profile_user, 'edit_posts' ) || current_user_can( 'edit_pages' );
 
 		if ( ! $can_edit || ! user_can( $profile_user, 'upload_files' ) ) {
 			return;


### PR DESCRIPTION
current_user_can() was passing the user object, which isn't a valid parameter and can cause a fatal when other plugins mess about with what they think is a string